### PR TITLE
Add features to import_plate_txis()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: velocessor
 Type: Package
 Title: The world's dumbest single-cell RNA velocity calculator and loader
 Description: Velocessor provides some convenience functions for RNA velocity loading, batch correction, and plotting in a Bioconductor environment. 
-Version: 0.13.14
+Version: 0.13.15
 Date: 2021-01-13
 Authors@R: person("Tim", "Triche, Jr.", role=c("aut", "cre"), email="trichelab@gmail.com")
 Author: Tim Triche, Jr. [aut, cre]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: velocessor
 Type: Package
 Title: The world's dumbest single-cell RNA velocity calculator and loader
 Description: Velocessor provides some convenience functions for RNA velocity loading, batch correction, and plotting in a Bioconductor environment. 
-Version: 0.13.13
+Version: 0.13.14
 Date: 2021-01-13
 Authors@R: person("Tim", "Triche, Jr.", role=c("aut", "cre"), email="trichelab@gmail.com")
 Author: Tim Triche, Jr. [aut, cre]
@@ -35,6 +35,7 @@ Imports:
     basilisk,
     eisaR,
     mclust,
+    mbkmeans,
     igraph,
     fishpond,
     jsonlite,
@@ -53,7 +54,6 @@ Suggests:
     compartmap (>= 1.7.2),
     harmony,
     symphony,
-    mbkmeans,
     tidyverse, 
     infercnv,
     annotationTools

--- a/R/import_plate_txis.R
+++ b/R/import_plate_txis.R
@@ -10,6 +10,7 @@
 #' @param   quants  where the quant.sf files are
 #' @param   t2g     required file with tx2gene information for TPM calcs
 #' @param   type    What type of quantifications are these? ("salmon") 
+#' @param   gtf     Where an expanded GTF lives if not already collapsed to gene-level
 #' @param   ...     additional parameters to pass to tximport, if any
 #' 
 #' @return          A SingleCellExperiment with 'spliced' & 'unspliced' assays.
@@ -22,7 +23,8 @@
 #' @import SingleCellExperiment
 #' 
 #' @export
-import_plate_txis <- function(quants, t2g=NA, type="salmon", ...) {
+import_plate_txis <- function(quants, t2g=NA, type="salmon",
+                              gtf=NULL, ...) {
 
   if (is.na(t2g)) {
     message("No transcript to gene mapping file provided. Cannot compute TPM.")
@@ -38,7 +40,13 @@ import_plate_txis <- function(quants, t2g=NA, type="salmon", ...) {
   if (!all(file.exists(quants))) stop("Some of your quant files don't exist.") 
   cmds <- sub("quant.*sf", "cmd_info.json", quants)
   if (!all(file.exists(cmds))) stop("Some quants don't have cmd_info.json")
-  gtfs <- sapply(cmds, .getGTF) 
+  if (!is.null(gtf)) {
+    stopifnot(file.exists(gtf))
+    gtfs <- gtf
+  } else {
+    ## this means they were collapsed to gene level already
+    gtfs <- sapply(cmds, .getGTF) 
+  }
   if (length(unique(gtfs)) > 1) stop("Some quants use different GTF files.") 
   gtf <- unique(gtfs)  
 

--- a/R/import_plate_txis.R
+++ b/R/import_plate_txis.R
@@ -5,6 +5,7 @@
 #' and so forth. 
 #' 
 #' FIXME: Add Kallisto support and Arkas style txome/repeatome/spikeome support.
+#' FIXME: Add in ability to support bootstraps/Gibbs samples from salmon
 #'
 #' @param   quants  where the quant.sf files are
 #' @param   t2g     required file with tx2gene information for TPM calcs
@@ -57,7 +58,14 @@ import_plate_txis <- function(quants, t2g=NA, type="salmon", ...) {
   message("Splitting...")
   feats <- sub("\\.gtf", ".features.tsv", gtf)
   cg <- read.delim(feats, header=TRUE, as.is=TRUE)
-  colnames(cg)[colnames(cg) == "intron"] <- "unspliced"
+  if ("intron" %in% colnames(cg)) {
+    message("WARNING: using a full-length protocol and only using intron pieces may miss relevant reads/unspliced transcripts.")
+    message("Ideally, you want to create the reference with 'unspliced' instead of 'introns' with eisaR.")
+    colnames(cg)[colnames(cg) == "intron"] <- "unspliced"
+  } else {
+    ## check to make sure 'unspliced' is there in the features tsv
+    stopifnot("unspliced" %in% colnames(cg))
+  }
   txis <- tximeta::splitSE(txi, cg, assayName="counts")
   assay(txis, "counts") <- assays(txis)[[1]] + assays(txis)[[2]]
   txis2 <- tximeta::splitSE(txi, cg, assayName="tpm")

--- a/man/import_plate_txis.Rd
+++ b/man/import_plate_txis.Rd
@@ -4,7 +4,7 @@
 \alias{import_plate_txis}
 \title{import plate-seq velocity information (from Salmon) to a SingleCellExperiment}
 \usage{
-import_plate_txis(quants, t2g = NA, type = "salmon", ...)
+import_plate_txis(quants, t2g = NA, type = "salmon", gtf = NULL, ...)
 }
 \arguments{
 \item{quants}{where the quant.sf files are}
@@ -12,6 +12,8 @@ import_plate_txis(quants, t2g = NA, type = "salmon", ...)
 \item{t2g}{required file with tx2gene information for TPM calcs}
 
 \item{type}{What type of quantifications are these? ("salmon")}
+
+\item{gtf}{Where an expanded GTF lives if not already collapsed to gene-level}
 
 \item{...}{additional parameters to pass to tximport, if any}
 }

--- a/man/import_plate_txis.Rd
+++ b/man/import_plate_txis.Rd
@@ -26,4 +26,5 @@ and so forth.
 }
 \details{
 FIXME: Add Kallisto support and Arkas style txome/repeatome/spikeome support.
+FIXME: Add in ability to support bootstraps/Gibbs samples from salmon
 }

--- a/man/import_plate_txis.Rd
+++ b/man/import_plate_txis.Rd
@@ -4,7 +4,14 @@
 \alias{import_plate_txis}
 \title{import plate-seq velocity information (from Salmon) to a SingleCellExperiment}
 \usage{
-import_plate_txis(quants, t2g = NA, type = "salmon", gtf = NULL, ...)
+import_plate_txis(
+  quants,
+  t2g = NA,
+  type = "salmon",
+  gtf = NULL,
+  qc = TRUE,
+  ...
+)
 }
 \arguments{
 \item{quants}{where the quant.sf files are}
@@ -14,6 +21,8 @@ import_plate_txis(quants, t2g = NA, type = "salmon", gtf = NULL, ...)
 \item{type}{What type of quantifications are these? ("salmon")}
 
 \item{gtf}{Where an expanded GTF lives if not already collapsed to gene-level}
+
+\item{qc}{Whether some quick QC should be performed to toss low-quality cells}
 
 \item{...}{additional parameters to pass to tximport, if any}
 }


### PR DESCRIPTION
- Add mbkmeans to imports to install
- Pick up "unspliced" and warning about using "introns" for full length plate-seq protocols
- Add option to include expanded GTF as a path if not in cmd_info.json
- Remove empty/failed cells prior to splitting SE and downstream analyses